### PR TITLE
Add an --update_source command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ extract = tldextract.TLDExtract(
 Use an absolute path when specifying the `suffix_list_urls` keyword argument.
 `os.path` is your friend.
 
+The command line update command can be used with a url or local file you specify:
+
+```zsh
+tldextract --update --update_source "http://foo.bar.baz"
+```
+
+This could be useful in production when you don't want the delay associated with updating the suffix
+list on first use, or if you are behind a complex firewall that prevents a simple update from working.
+
 ### FAQ
 
 #### Can you add suffix \_\_\_\_? Can you make an exception for domain \_\_\_\_?

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -40,7 +40,7 @@ def main():
     parser.add_argument('-u', '--update', default=False, action='store_true',
                         help='force fetch the latest TLD definitions')
     parser.add_argument('--update_source', action='append', required=False,
-                        help='use an alternate URL for TLD definitions. Can be repeated for multiple sources')
+                        help='use an alternate URL or local file for TLD definitions.')
     parser.add_argument('-c', '--cache_file',
                         help='use an alternate TLD definition file')
     parser.add_argument('-p', '--private_domains', default=False, action='store_true',

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -2,7 +2,10 @@
 
 
 import logging
+import os.path
 import sys
+
+import pathlib
 
 try:
     import pkg_resources
@@ -36,6 +39,8 @@ def main():
 
     parser.add_argument('-u', '--update', default=False, action='store_true',
                         help='force fetch the latest TLD definitions')
+    parser.add_argument('--update_source', action='append', required=False,
+                        help='use an alternate URL for TLD definitions. Can be repeated for multiple sources')
     parser.add_argument('-c', '--cache_file',
                         help='use an alternate TLD definition file')
     parser.add_argument('-p', '--private_domains', default=False, action='store_true',
@@ -46,6 +51,17 @@ def main():
 
     if args.cache_file:
         tld_extract.cache_file = args.cache_file
+
+    if args.update_source is not None:
+        suffix_list_urls = []
+        for source in args.update_source:
+            if os.path.isfile(source):
+                as_path_uri = pathlib.Path(os.path.abspath(source)).as_uri()
+                suffix_list_urls.append(as_path_uri)
+            else:
+                suffix_list_urls.append(source)
+
+        tld_extract.suffix_list_urls = suffix_list_urls
 
     if args.update:
         tld_extract.update(True)


### PR DESCRIPTION
This change adds an --update_source command line option to the command line interface.

The intended use, is that in production we don't want the delay associated with the default behaviour of updating when the API is called for the first time. This change also makes it possible to change the update URL without changing our main application, just the setup scripts.

This could be a better way to solve the problem that PR #150 is attempting to fix.

The README.md has been updated to document the new feature, but not the changelong.
